### PR TITLE
Fix links to SIP documentation

### DIFF
--- a/docs/command_line_tools.rst
+++ b/docs/command_line_tools.rst
@@ -2,7 +2,7 @@ Command Line Tools
 ==================
 
 PyQt-builder adds the following command line options to `SIP's build tools
-<https://www.riverbankcomputing.com/static/Docs/sip/command_line_tools.html>`__.
+<https://python-sip.readthedocs.io/en/latest/command_line_tools.html>`__.
 Unless stated otherwise, each option is added to all of the build tools.
 
 .. note::

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -31,7 +31,7 @@ implemented by the :py:mod:`pyqtbuild` module which also provides an API that
 can be used by a project's :file:`project.py` file.
 
 This documentation assumes you are already familiar with the `SIP documentation
-<https://www.riverbankcomputing.com/static/Docs/sip/>`__.
+<https://python-sip.readthedocs.io>`__.
 
 PyQt-builder is hosted at
 `GitHub <https://github.com/Python-PyQt/PyQt-builder>`__.

--- a/docs/pyproject_toml.rst
+++ b/docs/pyproject_toml.rst
@@ -2,7 +2,7 @@
 ================================
 
 PyQt-builder adds the following keys to those `implemented by SIP
-<https://www.riverbankcomputing.com/static/Docs/sip/pyproject_toml.html>`__.
+<https://python-sip.readthedocs.io/en/latest/pyproject_toml.html>`__.
 
 .. note::
     Individual projects may also add their own project-specific keys.


### PR DESCRIPTION
SIP doesn't seem to have a "stable" version on readthedocs.io, thus I used the `/latest/` URL, similar to what's already done in `example.rst`. Ultimately, either URL may be acceptable depending on how you plan to use "stable" vs. "latest" going forward. Another possibility is to use the `/page/` [automatic redirect](https://docs.readthedocs.io/en/stable/user-defined-redirects.html#page-redirects-at-page).