### PR TITLE
Added support for Qt v6.8

### DIFF
--- a/pyqtbuild/builder.py
+++ b/pyqtbuild/builder.py
@@ -5,7 +5,6 @@
 
 import os
 import sys
-import sysconfig
 
 from sipbuild import (Buildable, BuildableModule, Builder, Option, Project,
         PyProjectOptionException, UserException)
@@ -98,10 +97,19 @@ class QmakeBuilder(Builder):
             # Set the default minimum GLIBC version.  This is actually a
             # function of the build platform and it should really be determined
             # by inspecting the compiled extension module.  These defaults
-            # reflect the minimum versions provided by the supported Qt
-            # platforms at any particular time.
+            # reflect the minimum versions required by the Qt online installer
+            # for a particular version.
             if not project.minimum_glibc_version:
-                if self.qt_version >= 0x060000:
+                if self.qt_version >= 0x060800:
+                    from platform import processor
+
+                    # The arm64 build is based on Ubuntu 24.04 rather than
+                    # 22.04.
+                    if processor() == 'aarch64':
+                        project.minimum_glibc_version = '2.39'
+                    else:
+                        project.minimum_glibc_version = '2.35'
+                elif self.qt_version >= 0x060000:
                     project.minimum_glibc_version = '2.28'
                 else:
                     project.minimum_glibc_version = '2.17'

--- a/pyqtbuild/bundle/packages/__init__.py
+++ b/pyqtbuild/bundle/packages/__init__.py
@@ -8,6 +8,7 @@ from .pyqt6 import PyQt6
 from .pyqt6_3d import PyQt6_3D
 from .pyqt6_charts import PyQt6_Charts
 from .pyqt6_datavisualization import PyQt6_DataVisualization
+from .pyqt6_graphs import PyQt6_Graphs
 from .pyqt6_networkauth import PyQt6_NetworkAuth
 from .pyqt6_webengine import PyQt6_WebEngine
 

--- a/pyqtbuild/bundle/packages/pyqt3d.py
+++ b/pyqtbuild/bundle/packages/pyqt3d.py
@@ -16,7 +16,6 @@ _QT_METADATA = {
     'Qt3DCore':
         VersionedMetadata(
             lib_deps={'': ('Qt3DQuick', )},
-            qml=True,
             qml_names=('Qt3D', )),
 
     'Qt3DExtras':

--- a/pyqtbuild/bundle/packages/pyqt5.py
+++ b/pyqtbuild/bundle/packages/pyqt5.py
@@ -27,7 +27,7 @@ _QT_METADATA = {
             lib_deps={
                 'linux': ('QtConcurrent', ),
                 'macos': ('QtConcurrent', )},
-            qml=True),
+            ),
 
     'QtCore':
         VersionedMetadata(
@@ -60,9 +60,7 @@ _QT_METADATA = {
         VersionedMetadata(),
 
     'QtLocation':
-        VersionedMetadata(
-            lib_deps={'': ('QtPositioningQuick', )},
-            qml=True),
+        VersionedMetadata(lib_deps={'': ('QtPositioningQuick', )}),
 
     'QtMacExtras':
         VersionedMetadata(),
@@ -73,7 +71,7 @@ _QT_METADATA = {
                 '': ('QtMultimediaQuick', ),
                 'linux': ('QtMultimediaGstTools', )
             },
-            qml=True, qml_names=('QtAudioEngine', 'QtMultimedia')),
+            qml_names=('QtAudioEngine', 'QtMultimedia')),
 
     'QtMultimediaWidgets':
         VersionedMetadata(),
@@ -85,27 +83,24 @@ _QT_METADATA = {
         VersionedMetadata(legacy=True),
 
     'QtNfc':
-        VersionedMetadata(qml=True),
+        VersionedMetadata(),
 
     'QtOpenGL':
         VersionedMetadata(),
 
     'QtPositioning':
-        VersionedMetadata(qml=True),
+        VersionedMetadata(),
 
     'QtPrintSupport':
         VersionedMetadata(),
 
     'QtQml':
-        VersionedMetadata(
-            lib_deps={'': ('QtQmlModels', 'QtQmlWorkerScript')},
-            qml=True),
+        VersionedMetadata(lib_deps={'': ('QtQmlModels', 'QtQmlWorkerScript')}),
 
     'QtQuick':
         VersionedMetadata(
             lib_deps={'': ('QtQuickControls2', 'QtQuickParticles',
                     'QtQuickShapes', 'QtQuickTemplates2', 'QtQuickTest')},
-            qml=True,
             qml_names=('QtCanvas3D', 'QtGraphicalEffects', 'QtQuick',
                     'QtQuick.2')),
 
@@ -114,16 +109,16 @@ _QT_METADATA = {
             lib_deps={
                     '': ('QtQuick3DAssetImport', 'QtQuick3DRender',
                             'QtQuick3DRuntimeRender', 'QtQuick3DUtils')},
-            qml=True),
+            ),
 
     'QtQuickWidgets':
         VersionedMetadata(),
 
     'QtRemoteObjects':
-        VersionedMetadata(qml=True),
+        VersionedMetadata(),
 
     'QtSensors':
-        VersionedMetadata(qml=True),
+        VersionedMetadata(),
 
     'QtSerialPort':
         VersionedMetadata(),
@@ -135,19 +130,19 @@ _QT_METADATA = {
         VersionedMetadata(),
 
     'QtTest':
-        VersionedMetadata(qml=True),
+        VersionedMetadata(),
 
     'QtTextToSpeech':
         VersionedMetadata(),
 
     'QtWebChannel':
-        VersionedMetadata(qml=True),
+        VersionedMetadata(),
 
     'QtWebSockets':
-        VersionedMetadata(qml=True),
+        VersionedMetadata(),
 
     'QtWebView':
-        VersionedMetadata(qml=True),
+        VersionedMetadata(),
 
     'QtWidgets':
         VersionedMetadata(),
@@ -162,9 +157,7 @@ _QT_METADATA = {
         VersionedMetadata(),
 
     'QtXmlPatterns':
-        VersionedMetadata(
-            qml=True,
-            qml_names=('Qt', )),
+        VersionedMetadata(qml_names=('Qt', )),
 }
 
 

--- a/pyqtbuild/bundle/packages/pyqt6.py
+++ b/pyqtbuild/bundle/packages/pyqt6.py
@@ -14,7 +14,7 @@ _QT_METADATA = {
         VersionedMetadata(dll=False),
 
     'QtBluetooth':
-        VersionedMetadata(version=(6, 2, 0), qml=True),
+        VersionedMetadata(version=(6, 2, 0)),
 
     'QtCore': (
         VersionedMetadata(version=(6, 7, 0),
@@ -63,9 +63,19 @@ _QT_METADATA = {
         VersionedMetadata(),
 
     #'QtLocation':
-    #    VersionedMetadata(qml=True),
+    #    VersionedMetadata(),
 
     'QtMultimedia': (
+        VersionedMetadata(version=(6, 8, 0),
+                lib_deps={'': ('QtMultimediaQuick', )},
+                other_lib_deps={
+                    'macos': ('libavcodec.61.dylib', 'libavformat.61.dylib',
+                            'libavutil.59.dylib', 'libswresample.5.dylib',
+                            'libswscale.8.dylib'),
+                    'win': ('avcodec-61.dll', 'avformat-61.dll',
+                            'avutil-59.dll', 'swresample-5.dll',
+                            'swscale-8.dll')},
+                ),
         VersionedMetadata(version=(6, 7, 1),
                 lib_deps={'': ('QtMultimediaQuick', )},
                 other_lib_deps={
@@ -75,17 +85,17 @@ _QT_METADATA = {
                     'win': ('avcodec-60.dll', 'avformat-60.dll',
                             'avutil-58.dll', 'swresample-4.dll',
                             'swscale-7.dll')},
-                qml=True),
+                ),
         VersionedMetadata(version=(6, 7, 0),
                 lib_deps={'': ('QtMultimediaQuick', )},
                 other_lib_deps={
                     'win': ('avcodec-60.dll', 'avformat-60.dll',
                             'avutil-58.dll', 'swresample-4.dll',
                             'swscale-7.dll')},
-                qml=True),
+                ),
         VersionedMetadata(version=(6, 2, 0),
                 lib_deps={'': ('QtMultimediaQuick', )},
-                qml=True)),
+                )),
 
     'QtMultimediaWidgets':
         VersionedMetadata(version=(6, 2, 0)),
@@ -94,7 +104,7 @@ _QT_METADATA = {
         VersionedMetadata(),
 
     'QtNfc':
-        VersionedMetadata(version=(6, 2, 0), qml=True),
+        VersionedMetadata(version=(6, 2, 0)),
 
     'QtOpenGL':
         VersionedMetadata(),
@@ -112,23 +122,51 @@ _QT_METADATA = {
     'QtPositioning':
         VersionedMetadata(version=(6, 2, 0),
                 lib_deps={'': ('QtPositioningQuick', )},
-                qml=True),
+                ),
 
     'QtPrintSupport':
         VersionedMetadata(),
 
     'QtQml': (
+        VersionedMetadata(version=(6, 8, 0),
+                lib_deps={'': ('QtQmlMeta', 'QtQmlModels', 'QtQmlWorkerScript',
+                        'QtLabsAnimation', 'QtLabsFolderListModel',
+                        'QtLabsPlatform', 'QtLabsQmlModels', 'QtLabsSettings',
+                        'QtLabsSharedImage', 'QtLabsWavefrontMesh')},
+                ),
         VersionedMetadata(version=(6, 5, 0),
                 lib_deps={'': ('QtQmlModels', 'QtQmlWorkerScript',
                         'QtLabsAnimation', 'QtLabsFolderListModel',
                         'QtLabsQmlModels', 'QtLabsSettings',
                         'QtLabsSharedImage', 'QtLabsWavefrontMesh')},
-                qml=True),
+                ),
         VersionedMetadata(
                 lib_deps={'': ('QtQmlModels', 'QtQmlWorkerScript')},
-                qml=True)),
+                )),
 
     'QtQuick': (
+        VersionedMetadata(version=(6, 8, 0),
+                lib_deps={'': ('QtQuickControls2', 'QtQuickControls2Basic',
+                        'QtQuickControls2BasicStyleImpl',
+                        'QtQuickControls2Fusion',
+                        'QtQuickControls2FusionStyleImpl',
+                        'QtQuickControls2IOSStyleImpl',
+                        'QtQuickControls2Imagine',
+                        'QtQuickControls2ImagineStyleImpl',
+                        'QtQuickControls2Impl',
+                        'QtQuickControls2MacOSStyleImpl',
+                        'QtQuickControls2Material',
+                        'QtQuickControls2MaterialStyleImpl',
+                        'QtQuickControls2Universal',
+                        'QtQuickControls2UniversalStyleImpl',
+                        'QtQuickDialogs2', 'QtQuickDialogs2QuickImpl',
+                        'QtQuickDialogs2Utils', 'QtQuickEffects',
+                        'QtQuickLayouts',
+                        'QtQuickParticles', 'QtQuickShapes',
+                        'QtQuickTemplates2', 'QtQuickTest',
+                        'QtQuickTimeline', 'QtQuickTimelineBlendTrees',
+                        'QtQuickVectorImage', 'QtQuickVectorImageGenerator')},
+                ),
         VersionedMetadata(version=(6, 7, 0),
                 lib_deps={'': ('QtQuickControls2', 'QtQuickControls2Basic',
                         'QtQuickControls2BasicStyleImpl',
@@ -144,11 +182,12 @@ _QT_METADATA = {
                         'QtQuickControls2Universal',
                         'QtQuickControls2UniversalStyleImpl',
                         'QtQuickDialogs2', 'QtQuickDialogs2QuickImpl',
-                        'QtQuickDialogs2Utils', 'QtQuickLayouts',
+                        'QtQuickDialogs2Utils', 'QtQuickEffects',
+                        'QtQuickLayouts',
                         'QtQuickParticles', 'QtQuickShapes',
                         'QtQuickTemplates2', 'QtQuickTest',
                         'QtQuickTimeline', 'QtQuickTimelineBlendTrees')},
-                qml=True),
+                ),
         VersionedMetadata(version=(6, 6, 3),
                 lib_deps={'': ('QtQuickControls2', 'QtQuickControls2Basic',
                         'QtQuickControls2BasicStyleImpl',
@@ -166,7 +205,7 @@ _QT_METADATA = {
                         'QtQuickParticles', 'QtQuickShapes',
                         'QtQuickTemplates2', 'QtQuickTest',
                         'QtQuickTimeline')},
-                qml=True),
+                ),
         VersionedMetadata(version=(6, 2, 0),
                 lib_deps={'': ('QtQuickControls2', 'QtQuickControls2Impl',
                         'QtQuickDialogs2', 'QtQuickDialogs2QuickImpl',
@@ -174,24 +213,34 @@ _QT_METADATA = {
                         'QtQuickParticles', 'QtQuickShapes',
                         'QtQuickTemplates2', 'QtQuickTest',
                         'QtQuickTimeline')},
-                qml=True),
+                ),
         VersionedMetadata(
                 lib_deps={'': ('QtQuickControls2', 'QtQuickControls2Impl',
                         'QtQuickLayouts', 'QtQuickParticles', 'QtQuickShapes',
                         'QtQuickTemplates2', 'QtQuickTest')},
-                qml=True)),
+                )),
 
     'QtQuick3D': (
+        VersionedMetadata(version=(6, 8, 0),
+                lib_deps={
+                        '': ('QtConcurrent', 'QtQuick3DAssetImport',
+                        'QtQuick3DAssetUtils', 'QtQuick3DEffects',
+                        'QtQuick3DGlslParser', 'QtQuick3DHelpers',
+                        'QtQuick3DHelpersImpl', 'QtQuick3DIblBaker',
+                        'QtQuick3DParticles', 'QtQuick3DPhysics',
+                        'QtQuick3DPhysicsHelpers', 'QtQuick3DRuntimeRender',
+                        'QtQuick3DUtils', 'QtShaderTools', 'QtQuick3DXr')},
+                ),
         VersionedMetadata(version=(6, 7, 0),
                 lib_deps={
                         '': ('QtConcurrent', 'QtQuick3DAssetImport',
                         'QtQuick3DAssetUtils', 'QtQuick3DEffects',
-                        'QtQuick3DHelpers', 'QtQuick3DHelpersImpl',
-                        'QtQuick3DIblBaker', 'QtQuick3DParticles',
-                        'QtQuick3DPhysics', 'QtQuick3DPhysicsHelpers',
-                        'QtQuick3DRuntimeRender', 'QtQuick3DUtils',
-                        'QtShaderTools')},
-                qml=True),
+                        'QtQuick3DGlslParser', 'QtQuick3DHelpers',
+                        'QtQuick3DHelpersImpl', 'QtQuick3DIblBaker',
+                        'QtQuick3DParticles', 'QtQuick3DPhysics',
+                        'QtQuick3DPhysicsHelpers', 'QtQuick3DRuntimeRender',
+                        'QtQuick3DUtils', 'QtShaderTools')},
+                ),
         VersionedMetadata(version=(6, 6, 0),
                 lib_deps={
                         '': ('QtConcurrent', 'QtQuick3DAssetImport',
@@ -200,7 +249,7 @@ _QT_METADATA = {
                         'QtQuick3DParticles', 'QtQuick3DPhysics',
                         'QtQuick3DPhysicsHelpers', 'QtQuick3DRuntimeRender',
                         'QtQuick3DUtils', 'QtShaderTools')},
-                qml=True),
+                ),
         VersionedMetadata(version=(6, 4, 0),
                 lib_deps={
                         '': ('QtConcurrent', 'QtQuick3DAssetImport',
@@ -208,7 +257,7 @@ _QT_METADATA = {
                         'QtQuick3DHelpers', 'QtQuick3DIblBaker',
                         'QtQuick3DParticles', 'QtQuick3DRuntimeRender',
                         'QtQuick3DUtils', 'QtShaderTools')},
-                qml=True),
+                ),
         VersionedMetadata(version=(6, 1, 0),
                 lib_deps={
                         '': ('QtQuick3DAssetImport', 'QtQuick3DAssetUtils',
@@ -216,12 +265,12 @@ _QT_METADATA = {
                         'QtQuick3DIblBaker', 'QtQuick3DParticles',
                         'QtQuick3DRuntimeRender', 'QtQuick3DUtils',
                         'QtShaderTools')},
-                qml=True),
+                ),
         VersionedMetadata(
                 lib_deps={
                         '': ('QtQuick3DAssetImport', 'QtQuick3DRuntimeRender',
                         'QtQuick3DUtils', 'QtShaderTools')},
-                qml=True)),
+                )),
 
     'QtQuickWidgets':
         VersionedMetadata(),
@@ -229,12 +278,12 @@ _QT_METADATA = {
     'QtRemoteObjects':
         VersionedMetadata(version=(6, 2, 0),
                 lib_deps={'': ('QtRemoteObjectsQml', )},
-                qml=True),
+                ),
 
     'QtSensors':
         VersionedMetadata(version=(6, 2, 0),
                 lib_deps={'': ('QtSensorsQuick', )},
-                qml=True),
+                ),
 
     'QtSerialPort':
         VersionedMetadata(version=(6, 2, 0)),
@@ -253,20 +302,20 @@ _QT_METADATA = {
         VersionedMetadata(),
 
     'QtTest':
-        VersionedMetadata(qml=True),
+        VersionedMetadata(),
 
     'QtTextToSpeech':
-        VersionedMetadata(version=(6, 4, 0), qml=True),
+        VersionedMetadata(version=(6, 4, 0)),
 
     'QtWebChannel': (
         # The quick library may have been present from the start.
         VersionedMetadata(version=(6, 6, 0),
                 lib_deps={'': ('QtWebChannelQuick', )},
-                qml=True),
-        VersionedMetadata(version=(6, 2, 0), qml=True)),
+                ),
+        VersionedMetadata(version=(6, 2, 0))),
 
     'QtWebSockets':
-        VersionedMetadata(version=(6, 2, 0), qml=True),
+        VersionedMetadata(version=(6, 2, 0)),
 
     'QtWidgets':
         VersionedMetadata(),

--- a/pyqtbuild/bundle/packages/pyqt6_3d.py
+++ b/pyqtbuild/bundle/packages/pyqt6_3d.py
@@ -16,7 +16,6 @@ _QT_METADATA = {
     'Qt3DCore':
         VersionedMetadata(
             lib_deps={'': ('QtConcurrent', )},
-            qml=True,
             qml_names=('Qt3D', )),
 
     'Qt3DExtras':

--- a/pyqtbuild/bundle/packages/pyqt6_charts.py
+++ b/pyqtbuild/bundle/packages/pyqt6_charts.py
@@ -13,8 +13,8 @@ _QT_METADATA = {
         # It's likely that the QML library was required from the start.
         VersionedMetadata(version=(6, 5, 0),
                 lib_deps={'': ('QtChartsQml', )},
-                qml=True, lgpl=False),
-        VersionedMetadata(version=(6, 1, 0), qml=True, lgpl=False))
+                lgpl=False),
+        VersionedMetadata(version=(6, 1, 0), lgpl=False))
 }
 
 

--- a/pyqtbuild/bundle/packages/pyqt6_datavisualization.py
+++ b/pyqtbuild/bundle/packages/pyqt6_datavisualization.py
@@ -13,8 +13,8 @@ _QT_METADATA = {
         # It's likely that the QML library was required from the start.
         VersionedMetadata(version=(6, 5, 0),
                 lib_deps={'': ('QtDataVisualizationQml', )},
-                qml=True, lgpl=False),
-        VersionedMetadata(version=(6, 1, 0), qml=True, lgpl=False))
+                lgpl=False),
+        VersionedMetadata(version=(6, 1, 0), lgpl=False))
 }
 
 

--- a/pyqtbuild/bundle/packages/pyqt6_graphs.py
+++ b/pyqtbuild/bundle/packages/pyqt6_graphs.py
@@ -9,13 +9,16 @@ from ..qt_metadata import VersionedMetadata
 
 # The Qt meta-data for this package.
 _QT_METADATA = {
-    'QtPurchasing':
-        VersionedMetadata(),
+    'QtGraphs':
+        VersionedMetadata(version=(6, 8, 0), lgpl=False),
+
+    'QtGraphsWidgets':
+        VersionedMetadata(version=(6, 8, 0), lgpl=False),
 }
 
 
-class PyQtPurchasing(AbstractPackage):
-    """ The PyQtPurchasing package. """
+class PyQt6_Graphs(AbstractPackage):
+    """ The PyQt6-Graphs package. """
 
     def get_qt_metadata(self):
         """ Return the package-specific meta-data describing the parts of Qt to

--- a/pyqtbuild/bundle/packages/pyqt6_webengine.py
+++ b/pyqtbuild/bundle/packages/pyqt6_webengine.py
@@ -30,7 +30,7 @@ _QT_METADATA = {
     'QtWebEngineQuick':
         VersionedMetadata(version=(6, 2, 0),
             lib_deps={'': ('QtWebEngineQuickDelegatesQml', )},
-            qml=True, qml_names=['QtWebEngine']),
+            qml_names=['QtWebEngine']),
 
     'QtWebEngineWidgets':
         VersionedMetadata(version=(6, 2, 0)),

--- a/pyqtbuild/bundle/packages/pyqtchart.py
+++ b/pyqtbuild/bundle/packages/pyqtchart.py
@@ -10,7 +10,7 @@ from ..qt_metadata import VersionedMetadata
 # The Qt meta-data for this package.
 _QT_METADATA = {
     'QtChart':
-        VersionedMetadata(name='QtCharts', qml=True, lgpl=False),
+        VersionedMetadata(name='QtCharts', lgpl=False),
 }
 
 

--- a/pyqtbuild/bundle/packages/pyqtdatavisualization.py
+++ b/pyqtbuild/bundle/packages/pyqtdatavisualization.py
@@ -10,7 +10,7 @@ from ..qt_metadata import VersionedMetadata
 # The Qt meta-data for this package.
 _QT_METADATA = {
     'QtDataVisualization':
-        VersionedMetadata(qml=True, lgpl=False),
+        VersionedMetadata(lgpl=False),
 }
 
 

--- a/pyqtbuild/bundle/packages/pyqtwebengine.py
+++ b/pyqtbuild/bundle/packages/pyqtwebengine.py
@@ -10,7 +10,7 @@ from ..qt_metadata import VersionedMetadata
 # The Qt meta-data for this package.
 _QT_METADATA = {
     'QtWebEngine':
-        VersionedMetadata(qml=True, translations=('qtwebengine', )),
+        VersionedMetadata(translations=('qtwebengine', )),
 
     'QtWebEngineCore':
         VersionedMetadata(

--- a/pyqtbuild/bundle/qt_metadata.py
+++ b/pyqtbuild/bundle/qt_metadata.py
@@ -20,9 +20,8 @@ class VersionedMetadata:
 
     def __init__(self, *, version=None, name=None, lib_deps=None,
             other_lib_deps=None, exes=None, files=None, others=None, dll=True,
-            qml=False, qml_names=None, translations=None,
-            excluded_plugins=None, lgpl=True, legacy=False,
-            subwheel_files=None):
+            qml_names=None, translations=None, excluded_plugins=None,
+            lgpl=True, legacy=False, subwheel_files=None):
         """ Initialise the versioned bindings. """
 
         self._version = version
@@ -33,7 +32,6 @@ class VersionedMetadata:
         self._files = {} if files is None else files
         self._others = {} if others is None else others
         self._dll = dll
-        self._qml = qml
         self._qml_names = qml_names
         self._translations = () if translations is None else translations
         self._excluded_plugins = excluded_plugins
@@ -158,15 +156,12 @@ class VersionedMetadata:
                             skip_files=skip_files)
 
         # Bundle any QML files.
-        if self._qml:
-            qml_names = self._qml_names
-            if qml_names is None:
-                qml_names = [self._name]
+        qml_names = self._qml_names if qml_names is not None else [self._name]
 
-            for qml_subdir in qml_names:
-                self._bundle_nondebug(os.path.join('qml', qml_subdir),
-                        target_qt_dir, qt_dir, platform_tag, macos_thin_arch,
-                        ignore_missing, skip_files=skip_files)
+        for qml_subdir in qml_names:
+            self._bundle_nondebug(os.path.join('qml', qml_subdir),
+                    target_qt_dir, qt_dir, platform_tag, macos_thin_arch,
+                    ignore_missing, skip_files=skip_files)
 
         # Bundle any plugins.  We haven't done the analysis of which plugins
         # belong to which package so we assume that only the QtCore package


### PR DESCRIPTION
Added support for the QtGraphs module.

Linux wheels now require GLIBC v2.35 (eg. Ubuntu 22.04) on Intel and v2.39 (eg. Ubuntu 24.04) on Arm.

Resolves #16